### PR TITLE
Add SetActiveEnemyWave Event

### DIFF
--- a/AWO/Modules/WEE/Events/Door/SetActiveEnemyWaveEvent.cs
+++ b/AWO/Modules/WEE/Events/Door/SetActiveEnemyWaveEvent.cs
@@ -1,0 +1,38 @@
+﻿using AK;
+using LevelGeneration;
+
+namespace AWO.Modules.WEE.Events;
+
+internal sealed class SetActiveEnemyWaveEvent : BaseEvent
+{
+    public override WEE_Type EventType => WEE_Type.SetActiveEnemyWave;
+
+    protected override void TriggerCommon(WEE_EventData e)
+    {
+        if (!TryGetZoneEntranceSecDoor(e, out var door)) return;
+
+        var waveData = e.ActiveEnemyWave ?? new();
+        var state = door.m_sync.GetCurrentSyncState();
+        switch (state.status)
+        {
+            case eDoorStatus.Open:
+            case eDoorStatus.Opening:
+                LogError("Door is already open!");
+                break;
+
+            default:
+                if (door.ActiveEnemyWaveData?.HasActiveEnemyWave == true)
+                    door.m_sound.Post(EVENTS.MONSTER_RUCKUS_FROM_BEHIND_SECURITY_DOOR_LOOP_STOP);
+
+                door.SetupActiveEnemyWaveData(waveData);
+                if (!waveData.HasActiveEnemyWave)
+                {
+                    door.m_graphics.SetActiveEnemyWaveEnabled(enabled: false);
+                    door.m_locks.SetActiveEnemyWaveEnabled(enabled: false);
+                    door.m_anim.SetActiveEnemyWaveEnabled(enabled: false);
+                }
+                LogDebug($"Set enemy wave - Active: {waveData.HasActiveEnemyWave}, GroupInFront: {waveData.EnemyGroupInfrontOfDoor}, GroupInArea: {waveData.EnemyGroupInArea}");
+                break;
+        }
+    }
+}

--- a/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
+++ b/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
@@ -1,4 +1,6 @@
 ﻿using BepInEx.Logging;
+using CellMenu;
+using GTFO.API;
 using System.Collections;
 using UnityEngine;
 using ScreenType = AWO.Modules.WEE.WEE_SetSuccessScreen.ScreenType;
@@ -8,12 +10,14 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
 {
     public override WEE_Type EventType => WEE_Type.SetSuccessScreen;
 
+    private static string s_storedSuccessText = string.Empty;
+
     protected override void TriggerCommon(WEE_EventData e)
     {
         switch (e.SuccessScreen.Type)
         {
             case ScreenType.SetSuccessScreen:
-                SetScreen(e.SuccessScreen.CustomSuccessScreen);
+                SetScreen(e);
                 break;
             case ScreenType.FlashFakeScreen:
                 CoroutineManager.StartCoroutine(FakeScreen(e).WrapToIl2Cpp());
@@ -21,28 +25,30 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         }
     }
     
-    private static void SetScreen(string pageResourcePath)
+    private static void SetScreen(WEE_EventData e)
     {
-        if (pageResourcePath == string.Empty)
+        string pageResourcePath = e.SuccessScreen.CustomSuccessScreen;
+        if (pageResourcePath != string.Empty)
         {
-            Logger.Error("SetSuccessScreen", "Invalid CustomSuccessScreen!");
-            return;
+            try
+            {
+                RestoreSuccessText();
+                MainMenuGuiLayer.Current.PageExpeditionSuccess = MainMenuGuiLayer.Current.AddPage(eCM_MenuPage.CMP_EXPEDITION_SUCCESS, pageResourcePath).Cast<CM_PageExpeditionSuccess>();
+                Logger.Verbose(LogLevel.Debug, $"CustomSuccessScreen should now be changed to {pageResourcePath}");
+            }
+            catch
+            {
+                Logger.Error("SetSuccessScreen", $"CustomSuccessScreen asset {pageResourcePath} not found!");
+            }
         }
 
-        try
-        {
-            MainMenuGuiLayer.Current.AddPage(eCM_MenuPage.CMP_EXPEDITION_SUCCESS, pageResourcePath);
-            Logger.Verbose(LogLevel.Debug, $"CustomSuccessScreen should now be changed to {pageResourcePath}");
-        }
-        catch
-        {
-            Logger.Error("SetSuccessScreen", $"CustomSuccessScreen asset {pageResourcePath} not found!");
-        }
+        SetSuccessText(e.SpecialText);
     }
-    
+
     static IEnumerator FakeScreen(WEE_EventData e)
     {
         Logger.Verbose(LogLevel.Debug, "Enabling fake end screen... Disabled map and menu toggle");
+        SetSuccessText(e.SpecialText);
         FocusStateManager.EnterMenu(e.SuccessScreen.FakeEndScreen, force: true);
         FocusStateManager.MapToggleAllowed = false;
         FocusStateManager.MenuToggleAllowed = false;
@@ -50,9 +56,37 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         yield return new WaitForSeconds(e.Duration);
 
         Logger.Verbose(LogLevel.Debug, "Disabling fake end screen... Enabled map and menu toggle");
+        RestoreSuccessText();
         FocusStateManager.ExitMenu();
         FocusStateManager.ChangeState(eFocusState.FPS, force: true);
         FocusStateManager.MapToggleAllowed = true;
         FocusStateManager.MenuToggleAllowed = true;
+    }
+
+    private static void SetSuccessText(string text)
+    {
+        if (text == string.Empty)
+        {
+            return;
+        }
+
+        if (s_storedSuccessText == string.Empty)
+        {
+            s_storedSuccessText = MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.text;
+            LevelAPI.OnBuildStart += RestoreSuccessText; // Any event that fires after the player leaves the success screen
+        }
+
+        MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(text);
+        Logger.Verbose(LogLevel.Debug, $"Set success screen text to {text})");
+    }
+
+    private static void RestoreSuccessText()
+    {
+        if (s_storedSuccessText != string.Empty)
+        {
+            MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(s_storedSuccessText);
+            s_storedSuccessText = string.Empty;
+            LevelAPI.OnBuildStart -= RestoreSuccessText;
+        }
     }
 }

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -88,6 +88,9 @@ public sealed class WEE_EventData
     public WEE_SetTerminalLog SetTerminalLog { get; set; } = new();
     public WEE_SetTerminalLog TerminalLog { get => SetTerminalLog; set => SetTerminalLog = value; }
     public List<WEE_SetPocketItem> ObjectiveItems { get; set; } = new();
+
+    // Dinorush
+    public ActiveEnemyWaveData? ActiveEnemyWave { get; set; } = null;
 }
 
 #region OG_EVENTS

--- a/AWO/Modules/WEE/WEE_Type.cs
+++ b/AWO/Modules/WEE/WEE_Type.cs
@@ -58,5 +58,8 @@ public enum WEE_Type
     SetPocketItem,
     DoInteractWeakDoorsInZone,
     ToggleInteractWeakDoorsInZone,
-    PickupSentries
+    PickupSentries,
+
+    // Dinorush AWO Events:
+    SetActiveEnemyWave = WEE_EnumInjector.ExtendedIndex + 20000
 }

--- a/AWO/Modules/WEE/WEE_Type.cs
+++ b/AWO/Modules/WEE/WEE_Type.cs
@@ -33,6 +33,9 @@ public enum WEE_Type
     UnhideTerminalCommand,
     AddChainPuzzleToSecurityDoor,
 
+    // Dinorush AWO Events:
+    SetActiveEnemyWave,
+
     // Amor AWO Events:
     NestedEvent = WEE_EnumInjector.ExtendedIndex + 10000,
     StartEventLoop,
@@ -59,7 +62,4 @@ public enum WEE_Type
     DoInteractWeakDoorsInZone,
     ToggleInteractWeakDoorsInZone,
     PickupSentries,
-
-    // Dinorush AWO Events:
-    SetActiveEnemyWave = WEE_EnumInjector.ExtendedIndex + 20000
 }


### PR DESCRIPTION
As title states, lets you add/remove blood doors to a security door.

Tested with:
1. Adding wave to a normal sec door
2. Overriding the wave of an existing blood door
3. Removing the wave of an existing blood door

Only odd thing that occurred is Woods played a blood door voiceline for 3 once. Probably a ChatterReborn issue (didn't see anything relevant in r6mono), not really worth debugging.

Edit:
Additionally, added functionality to let you modify expedition success text with SetSuccessScreen using the base WardenEventData `SpecialText` field. An empty field does not modify the text from whatever it currently is.

Tested with:
1. Dropping, triggering event
2. Dropping, triggering event, redropping, triggering event, extracting
3. Dropping, triggering event, redropping, extracting

Does apply to the FakeEndScreen, but only for the normal success screen. After it runs, it resets the text, so any previous custom text would need to be re-applied. Not the best implementation but I don't expect these features to be used in tandem much if at all, so was lazy.