### PR TITLE
Tgb dev

### DIFF
--- a/AWO/Modules/WEE/Events/Objective/ModifyReactorWaveStateEvent.cs
+++ b/AWO/Modules/WEE/Events/Objective/ModifyReactorWaveStateEvent.cs
@@ -33,7 +33,7 @@ internal sealed class ModifyReactorWaveStateEvent : BaseEvent
                     state.stateCount = e.Reactor.Wave;
 
                 // only change duration if different from -1
-                if (e.Reactor.Duration != -1)
+                if (e.Reactor.Duration != null && e.Reactor.Duration > 0)
                 {
                     // calculate how many seconds passed to make sure seconds passed remains the exact same
                     // notice this change is done prior to the e.Reactor.Progress check which means it does nothing
@@ -43,8 +43,8 @@ internal sealed class ModifyReactorWaveStateEvent : BaseEvent
                     // updates the total timer so that:
                     // 1. the timer from now progresses slower.
                     // 2. the bar at the top updates properly.
-                    reactor.m_currentDuration = e.Reactor.Duration;
-                    state.stateProgress = newPercent;
+                    reactor.m_currentDuration = (float) e.Reactor.Duration;
+                    state.stateProgress = (float) newPercent;
                 }
 
                 // only change progress if different from -1

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -92,6 +92,9 @@ public sealed class WEE_EventData
 
     // Dinorush
     public ActiveEnemyWaveData? ActiveEnemyWave { get; set; } = null;
+
+    // Tgb03
+
 }
 
 #region OG_EVENTS
@@ -119,7 +122,7 @@ public sealed class WEE_ReactorEventData
     public WaveState State { get; set; } = WaveState.Intro;
     public int Wave { get; set; } = 1;
     public float Progress { get; set; } = 0.0f;
-    public float Duration { get; set; } = -1f;
+    public float? Duration { get; set; } = null;
 
     public enum WaveState
     {

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -119,6 +119,7 @@ public sealed class WEE_ReactorEventData
     public WaveState State { get; set; } = WaveState.Intro;
     public int Wave { get; set; } = 1;
     public float Progress { get; set; } = 0.0f;
+    public float Duration { get; set; } = -1f;
 
     public enum WaveState
     {


### PR DESCRIPTION
Added ability to change the duration of a reactor timer during the timer.

Added directly to `WEE_ReactorEventData` duration field. I don't know if this would be better if it was its own event type or not. But the current implementation makes sure that the behaviour remains unchanged if the duration field is left null or a non positive float.

Branch has been left with editing allowed for maintainers of AWO in case this is not considered ok. The feature is potentially interesting so in case someone wants it here it is.

I have also made the changes to the wiki documentation however because Github is ass, it doesn't support merges for wikis so here is the wiki fork i made. https://github.com/Tgb03/AdvancedWardenObjective.wiki.git