### PR TITLE
Add Music Override field to Custom Success Screen

### DIFF
--- a/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
+++ b/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
@@ -113,8 +113,8 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
     {
         if (s_storedPreviousMusic != 0)
         {
-            MainMenuGuiLayer.Current.PageExpeditionSuccess.m_overrideSuccessMusic = music;
-            s_storedSuccessText = 0;
+            MainMenuGuiLayer.Current.PageExpeditionSuccess.m_overrideSuccessMusic = s_storedPreviousMusic;
+            s_storedPreviousMusic = 0;
             LevelAPI.OnBuildStart -= RestoreSuccessMusic;
         }
     }

--- a/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
+++ b/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
@@ -11,6 +11,7 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
     public override WEE_Type EventType => WEE_Type.SetSuccessScreen;
 
     private static string s_storedSuccessText = string.Empty;
+    private static uint s_storedPreviousMusic = 0;
 
     protected override void TriggerCommon(WEE_EventData e)
     {
@@ -43,6 +44,7 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         }
 
         SetSuccessText(e.SpecialText);
+        SetSuccessMusic(e.SuccessScreen.OverrideMusic);
     }
 
     static IEnumerator FakeScreen(WEE_EventData e)
@@ -77,7 +79,24 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         }
 
         MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(text);
-        Logger.Verbose(LogLevel.Debug, $"Set success screen text to {text})");
+        Logger.Verbose(LogLevel.Debug, $"Set success screen text to {text}.");
+    }
+    
+    private static void SetSuccessMusic(uint music)
+    {
+        if (music == 0)
+        {
+            return;
+        }
+
+        if (s_storedPreviousMusic == 0)
+        {
+            s_storedPreviousMusic = MainMenuGuiLayer.Current.PageExpeditionSuccess.m_overrideSuccessMusic;
+            LevelAPI.OnBuildStart += RestoreSuccessMusic; // Any event that fires after the player leaves the success screen
+        }
+
+        MainMenuGuiLayer.Current.PageExpeditionSuccess.m_overrideSuccessMusic = music;
+        Logger.Verbose(LogLevel.Debug, $"Set success screen music to sound id {music}.");
     }
 
     private static void RestoreSuccessText()
@@ -87,6 +106,16 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
             MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(s_storedSuccessText);
             s_storedSuccessText = string.Empty;
             LevelAPI.OnBuildStart -= RestoreSuccessText;
+        }
+    }
+    
+    private static void RestoreSuccessMusic()
+    {
+        if (s_storedPreviousMusic != 0)
+        {
+            MainMenuGuiLayer.Current.PageExpeditionSuccess.m_overrideSuccessMusic = music;
+            s_storedSuccessText = 0;
+            LevelAPI.OnBuildStart -= RestoreSuccessMusic;
         }
     }
 }

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -449,6 +449,7 @@ public sealed class WEE_SetSuccessScreen
     public ScreenType Type { get; set; } = ScreenType.SetSuccessScreen;
     public WinScreen CustomSuccessScreen { get; set; } = WinScreen.Empty;
     public eCM_MenuPage FakeEndScreen { get; set; } = eCM_MenuPage.CMP_EXPEDITION_SUCCESS;
+    public uint OverrideMusic { get; set; } = 0;
     public enum ScreenType : byte
     {
         SetSuccessScreen,


### PR DESCRIPTION
Currently there's no way to override the default music when using the SetSuccessScreen event, I feel this should be supported.

I've added an extra field to the SetSuccessScreen details, and set up a similar method to the text so it's restored to its previous state.

This would also need a slight wiki modification, I've provided the used ones below.

NOTE: I am unable to compile and test this, since this project is set up for Windows compilation and I do not use Windows.

```
  AK.EVENTS_TypeInfo->static_fields->MUSIC_EXPEDITION_FAILED = 2641866888;
  AK.EVENTS_TypeInfo->static_fields->MUSIC_EXPEDITION_SUCCESSFUL = 3050927901;
  AK.EVENTS_TypeInfo->static_fields->MUSIC_EXPEDITION_SUCCESSFUL_R8C2 = 3105031969;
  AK.EVENTS_TypeInfo->static_fields->MUSIC_EXPEDITION_SUCCESSFUL_R8E1 = 3205697716;
  AK.EVENTS_TypeInfo->static_fields->MUSIC_EXPEDITION_SUCCESSFUL_R8E2 = 3205697719;
  ```