### PR TITLE
Fix duplicate client calls

### DIFF
--- a/AWO/Modules/WEE/Events/Door/LockSecurityDoorEvent.cs
+++ b/AWO/Modules/WEE/Events/Door/LockSecurityDoorEvent.cs
@@ -8,9 +8,9 @@ internal sealed class LockSecurityDoorEvent : BaseEvent
     public override WEE_Type EventType => WEE_Type.LockSecurityDoor;
     public override bool AllowArrayableGlobalIndex => true;
 
-    protected override void TriggerCommon(WEE_EventData e)
+    protected override void TriggerMaster(WEE_EventData e)
     {
-        if (!TryGetZoneEntranceSecDoor(e, out var door)) 
+        if (!TryGetZoneEntranceSecDoor(e, out var door))
             return;
 
         var state = door.m_sync.GetCurrentSyncState();
@@ -25,11 +25,17 @@ internal sealed class LockSecurityDoorEvent : BaseEvent
         }
 
         var sync = door.m_sync.TryCast<LG_Door_Sync>();
-        if (sync == null) 
+        if (sync == null)
             return;
-        
+
         state.status = eDoorStatus.Closed_LockedWithNoKey;
         sync.m_stateReplicator.State = state;
+    }
+
+    protected override void TriggerCommon(WEE_EventData e)
+    {
+        if (!TryGetZoneEntranceSecDoor(e, out var door)) 
+            return;
 
         var intMessage = door.gameObject.GetComponentInChildren<Interact_MessageOnScreen>();
         if (intMessage != null)

--- a/AWO/Modules/WEE/Events/Enemy/AlertEnemiesInZoneEvent.cs
+++ b/AWO/Modules/WEE/Events/Enemy/AlertEnemiesInZoneEvent.cs
@@ -11,7 +11,7 @@ internal sealed class AlertEnemiesInZoneEvent : BaseEvent
     public override WEE_Type EventType => WEE_Type.AlertEnemiesInZone;
     public override bool AllowArrayableGlobalIndex => true;
 
-    protected override void TriggerCommon(WEE_EventData e)
+    protected override void TriggerMaster(WEE_EventData e)
     {
         if (!TryGetZone(e, out var zone)) 
             return;


### PR DESCRIPTION
LockSecurityDoorEvent event would fire for each client, causing the door to lock [Player Count] times. If you did this the moment a door was unlocked, this could cause the door to fire off an unlock event for every single one as well (probably due to order of incoming packets). Can't test the latter at this time but this should at least fix the first.

AlertEnemiesInZone has no real issues but there is no point for clients to run the code. It just means host runs [Player Count] noises.