### PR TITLE
Add Arrayable Condition, GiveResource Event

### DIFF
--- a/AWO/Jsons/Arrayable.cs
+++ b/AWO/Jsons/Arrayable.cs
@@ -26,6 +26,9 @@ public struct Arrayable<T>
         Values = new List<T>(values);
     }
 
+    public readonly T this[int index] => Values[index];
+    public readonly IEnumerator<T> GetEnumerator() => Values.GetEnumerator();
+
     public static implicit operator Arrayable<T>(T value) => new(value);
     public static implicit operator Arrayable<T>(T[] values) => new(values);
     public static implicit operator Arrayable<T>(List<T> values) => new(values);

--- a/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
+++ b/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
@@ -34,13 +34,13 @@ internal sealed class GiveResourceEvent : BaseEvent
     {
         if (data.HasAnyAmmoGain)
         {
-            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.GetModifierValue(player, AgentModifier.AmmoSupport) : 1f;
+            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.ApplyModifier(player, AgentModifier.AmmoSupport, 1f) : 1f;
             PlayerBackpackManager.GiveAmmoToPlayer(player.Owner, data.MainAmmo * mod, data.SpecialAmmo * mod, data.ToolAmmo * mod);
         }
 
         if (data.Health != 0f)
         {
-            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.GetModifierValue(player, AgentModifier.HealSupport) : 1f;
+            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.ApplyModifier(player, AgentModifier.HealSupport, 1f) : 1f;
             player.GiveHealth(player, data.Health * mod);
         }
     }

--- a/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
+++ b/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
@@ -1,0 +1,40 @@
+﻿using Player;
+
+namespace AWO.Modules.WEE.Events;
+
+internal sealed class GiveResourceEvent : BaseEvent
+{
+    public override WEE_Type EventType => WEE_Type.GiveResource;
+    public override bool AllowArrayableGlobalIndex => true;
+
+    protected override void TriggerMaster(WEE_EventData e)
+    {
+        var data = e.GiveResource ?? new();
+        var activeSlotIndices = new HashSet<int>(data.PlayerFilter.Select(filter => (int)filter));
+
+        LevelGeneration.LG_Zone? zone = null;
+        if (data.UseLocation && !TryGetZone(e, out zone)) 
+            return;
+
+        bool overflow = data.FullTeamOverflow && activeSlotIndices.Count == 4 && activeSlotIndices.Max() < 4;
+        for (int i = 0; i < PlayerManager.PlayerAgentsInLevel.Count; i++)
+        {
+            var player = PlayerManager.PlayerAgentsInLevel[i];
+
+            if (!overflow && !activeSlotIndices.Contains(i))
+                continue; // Player not in PlayerFilter, continue
+            if (data.UseLocation && player.CourseNode?.m_zone.ID != zone!.ID)
+                continue; // Node is null, continue
+
+            GiveResource(player, data);
+        }
+    }
+
+    private static void GiveResource(PlayerAgent player, WEE_GiveResource data)
+    {
+        if (data.HasAnyAmmoGain)
+            PlayerBackpackManager.GiveAmmoToPlayer(player.Owner, data.MainAmmo, data.SpecialAmmo, data.ToolAmmo);
+        if (data.Health != 0f)
+            player.GiveHealth(player, data.Health);
+    }
+}

--- a/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
+++ b/AWO/Modules/WEE/Events/Player/GiveResourceEvent.cs
@@ -33,8 +33,15 @@ internal sealed class GiveResourceEvent : BaseEvent
     private static void GiveResource(PlayerAgent player, WEE_GiveResource data)
     {
         if (data.HasAnyAmmoGain)
-            PlayerBackpackManager.GiveAmmoToPlayer(player.Owner, data.MainAmmo, data.SpecialAmmo, data.ToolAmmo);
+        {
+            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.GetModifierValue(player, AgentModifier.AmmoSupport) : 1f;
+            PlayerBackpackManager.GiveAmmoToPlayer(player.Owner, data.MainAmmo * mod, data.SpecialAmmo * mod, data.ToolAmmo * mod);
+        }
+
         if (data.Health != 0f)
-            player.GiveHealth(player, data.Health);
+        {
+            float mod = data.IncludeSupplyEfficiency ? AgentModifierManager.GetModifierValue(player, AgentModifier.HealSupport) : 1f;
+            player.GiveHealth(player, data.Health * mod);
+        }
     }
 }

--- a/AWO/Modules/WEE/JsonInjects/ArrayableFlatConditionConverter.cs
+++ b/AWO/Modules/WEE/JsonInjects/ArrayableFlatConditionConverter.cs
@@ -1,0 +1,48 @@
+﻿using GameData;
+using Il2CppJsonNet;
+using Il2CppJsonNet.Linq;
+using InjectLib.JsonNETInjection.Converter;
+
+namespace AWO.Modules.WEE.JsonInjects;
+
+internal class ArrayableFlatConditionConverter : Il2CppJsonReferenceTypeConverter<WorldEventConditionPair>
+{
+    protected override WorldEventConditionPair Read(JToken jToken, WorldEventConditionPair existingValue, JsonSerializer serializer)
+    {
+        switch (jToken.Type)
+        {
+            case JTokenType.Array:
+                var arr = jToken.Cast<JArray>();
+                if (arr.Count > 0)
+                    return ReadToken(arr[0]);
+                return new();
+
+            case JTokenType.Object:
+                return ReadToken(jToken);
+
+            default:
+                return new();
+        }
+    }
+
+    private static WorldEventConditionPair ReadToken(JToken token)
+    {
+        var jObject = token.Cast<JObject>();
+        WorldEventConditionPair result = new();
+        if (jObject.TryGetValue(nameof(WorldEventConditionPair.ConditionIndex), out var idx))
+            result.ConditionIndex = (int) idx;
+        if (jObject.TryGetValue(nameof(WorldEventConditionPair.IsTrue), out var isTrue))
+            result.IsTrue = (bool) isTrue;
+        return result;
+    }
+
+    protected override void Write(JsonWriter writer, WorldEventConditionPair value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName(nameof(WorldEventConditionPair.ConditionIndex));
+        writer.WriteValue(value.ConditionIndex);
+        writer.WritePropertyName(nameof(WorldEventConditionPair.IsTrue));
+        writer.WriteValue(value.IsTrue);
+        writer.WriteEndObject();
+    }
+}

--- a/AWO/Modules/WEE/JsonInjects/ArrayableFlatEnumConverter.cs
+++ b/AWO/Modules/WEE/JsonInjects/ArrayableFlatEnumConverter.cs
@@ -4,7 +4,7 @@ using InjectLib.JsonNETInjection.Converter;
 
 namespace AWO.Modules.WEE.JsonInjects;
 
-internal class ArrayableFlatConverter<T> : Il2CppJsonUnmanagedTypeConverter<T> where T : unmanaged, Enum
+internal class ArrayableFlatEnumConverter<T> : Il2CppJsonUnmanagedTypeConverter<T> where T : unmanaged, Enum
 {
     private static readonly bool IsByte = Enum.GetUnderlyingType(typeof(T)) == typeof(byte);
 
@@ -13,7 +13,8 @@ internal class ArrayableFlatConverter<T> : Il2CppJsonUnmanagedTypeConverter<T> w
         switch (jToken.Type)
         {
             case JTokenType.Array:
-                if (jToken is JArray arr && arr?.Count > 0)
+                var arr = jToken.Cast<JArray>();
+                if (arr.Count > 0)
                     return ParseEnum(arr[0]);
                 return default;
 

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -304,6 +304,7 @@ public sealed class WEE_GiveResource
     public HashSet<PlayerIndex> PlayerFilter { get; set; } = new(Enum.GetValues<PlayerIndex>());
     public bool FullTeamOverflow { get; set; } = true;
     public bool UseLocation { get; set; } = false;
+    public bool IncludeSupplyEfficiency { get; set; } = false;
     public bool HasAnyAmmoGain => MainAmmo != 0f || SpecialAmmo != 0f || ToolAmmo != 0f;
     public bool HasAnyGain => Health != 0f && HasAnyAmmoGain;
 }

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -17,12 +17,9 @@ namespace AWO.Modules.WEE;
 public sealed class WEE_EventData
 {
     // Vanilla Fields for Serialization
-    public WEE_Type Type { get; set; }    
-    public WorldEventConditionPair Condition { get; set; } = new()
-    {
-        ConditionIndex = -1,
-        IsTrue = false
-    };
+    public WEE_Type Type { get; set; }
+
+    public Arrayable<WorldEventConditionPair> Condition { get; set; } = new WorldEventConditionPair();
     public eWardenObjectiveEventTrigger Trigger { get; set; } = eWardenObjectiveEventTrigger.None;
     public uint ChainPuzzle { get; set; } = 0u;
     public bool UseStaticBioscanPoints { get; set; } = false;
@@ -76,6 +73,9 @@ public sealed class WEE_EventData
     public Arrayable<WEE_HideTerminalCommand> HideCommand { private get => HideTerminalCommand; set => HideTerminalCommand = value; }
     public Arrayable<WEE_UnhideTerminalCommand> UnhideTerminalCommand { get; set; } = new();
     public Arrayable<WEE_UnhideTerminalCommand> UnhideCommand { private get => UnhideTerminalCommand; set => UnhideTerminalCommand = value; }
+
+    // Dino
+    public WEE_GiveResource GiveResource { get; set; } = new();
 
     // Amor
     public WEE_NestedEvent? NestedEvent { get; set; } = null;
@@ -291,6 +291,21 @@ public sealed class WEE_UnhideTerminalCommand
     public int TerminalIndex { get; set; } = 0; 
     public TERM_Command CommandEnum { get; set; } = TERM_Command.None;
     public int CommandNumber { get; set; } = 0;
+}
+#endregion
+
+#region DINO_EVENTS
+public sealed class WEE_GiveResource
+{
+    public float Health { get; set; } = 0f;
+    public float MainAmmo { get; set; } = 0f;
+    public float SpecialAmmo { get; set; } = 0f;
+    public float ToolAmmo { get; set; } = 0f;
+    public HashSet<PlayerIndex> PlayerFilter { get; set; } = new(Enum.GetValues<PlayerIndex>());
+    public bool FullTeamOverflow { get; set; } = true;
+    public bool UseLocation { get; set; } = false;
+    public bool HasAnyAmmoGain => MainAmmo != 0f || SpecialAmmo != 0f || ToolAmmo != 0f;
+    public bool HasAnyGain => Health != 0f && HasAnyAmmoGain;
 }
 #endregion
 

--- a/AWO/Modules/WEE/WEE_Type.cs
+++ b/AWO/Modules/WEE/WEE_Type.cs
@@ -35,6 +35,7 @@ public enum WEE_Type
 
     // Dinorush AWO Events:
     SetActiveEnemyWave,
+    GiveResource,
 
     // Amor AWO Events:
     NestedEvent = WEE_EnumInjector.ExtendedIndex + 10000,

--- a/AWO/Modules/WEE/WardenEventExt.cs
+++ b/AWO/Modules/WEE/WardenEventExt.cs
@@ -48,9 +48,10 @@ internal static class WardenEventExt
         ClassInjector.RegisterTypeInIl2Cpp<ZoneLightReplicator>();
 
         JsonInjector.SetConverter(new EventTypeConverter());
-        JsonInjector.SetConverter(new ArrayableFlatConverter<eDimensionIndex>());
-        JsonInjector.SetConverter(new ArrayableFlatConverter<LG_LayerType>());
-        JsonInjector.SetConverter(new ArrayableFlatConverter<eLocalZoneIndex>());
+        JsonInjector.SetConverter(new ArrayableFlatConditionConverter());
+        JsonInjector.SetConverter(new ArrayableFlatEnumConverter<eDimensionIndex>());
+        JsonInjector.SetConverter(new ArrayableFlatEnumConverter<LG_LayerType>());
+        JsonInjector.SetConverter(new ArrayableFlatEnumConverter<eLocalZoneIndex>());
         JsonInjector.AddHandler(new EventDataHandler());
         JsonInjector.AddHandler(new TriggerDataHandler());
 
@@ -110,10 +111,13 @@ internal static class WardenEventExt
             }
         }
 
-        if (WorldEventManager.GetCondition(e.Condition.ConditionIndex) != e.Condition.IsTrue)
+        foreach (var condition in e.Condition)
         {
-            Logger.Verbose(LogLevel.Debug, $"Condition {e.Condition.ConditionIndex} is not met");
-            yield break;
+            if (WorldEventManager.GetCondition(condition.ConditionIndex) != condition.IsTrue)
+            {
+                Logger.Verbose(LogLevel.Debug, $"Condition {condition.ConditionIndex} is not met");
+                yield break;
+            }
         }
 
         WOManager.DisplayWardenIntel(e.Layer, e.WardenIntel);


### PR DESCRIPTION
Makes Condition an Arrayable, allowing a list of Condition objects to be required for a single (AWO) event.

Adds the GiveResource event, which lets you give ammo/health/tool (and probably take away?) to each player.

Fixes ForceCompleteChainedPuzzle issues with cluster scans where spline audio and child scans remained active.

_Dev_
Adds an Index operator and an Enumerator to Arrayable to allow iteration without accessing values. Wanted to slightly clean up the existing usage in the code but left it out for now to keep the PR focused.