### PR TITLE
SetSuccessScreen fixes

### DIFF
--- a/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
+++ b/AWO/Modules/WEE/Events/Level/SetSuccessScreenEvent.cs
@@ -1,16 +1,20 @@
 ﻿using BepInEx.Logging;
 using CellMenu;
 using GTFO.API;
+using Localization;
 using System.Collections;
 using UnityEngine;
 using ScreenType = AWO.Modules.WEE.WEE_SetSuccessScreen.ScreenType;
 
 namespace AWO.Modules.WEE.Events;
+
 internal sealed class SetSuccessScreenEvent : BaseEvent
 {
     public override WEE_Type EventType => WEE_Type.SetSuccessScreen;
 
+    private static CM_PageExpeditionSuccess? s_storedPage = null;
     private static string s_storedSuccessText = string.Empty;
+    private static bool s_changedOrigText = false;
     private static bool s_shouldResetMusic = false;
 
     protected override void TriggerCommon(WEE_EventData e)
@@ -36,8 +40,7 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
             try
             {
                 RestoreSuccessText();
-                MainMenuGuiLayer.Current.PageExpeditionSuccess = MainMenuGuiLayer.Current.AddPage(eCM_MenuPage.CMP_EXPEDITION_SUCCESS, pageResourcePath).Cast<CM_PageExpeditionSuccess>();
-                Logger.Verbose(LogLevel.Debug, $"CustomSuccessScreen should now be changed to {pageResourcePath}");
+                SetSuccessPage(pageResourcePath);
             }
             catch
             {
@@ -67,18 +70,39 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         FocusStateManager.MenuToggleAllowed = true;
     }
 
+    private static void SetSuccessPage(string pageResourcePath)
+    {
+        if (s_storedPage == null)
+        {
+            s_storedPage = MainMenuGuiLayer.Current.PageExpeditionSuccess;
+            LevelAPI.OnBuildStart += RestoreSuccessPage; // Any event that fires after the player leaves the success screen
+        }
+        else
+            GameObject.Destroy(MainMenuGuiLayer.Current.PageExpeditionSuccess.gameObject);
+
+        MainMenuGuiLayer.Current.PageExpeditionSuccess = MainMenuGuiLayer.Current.AddPage(eCM_MenuPage.CMP_EXPEDITION_SUCCESS, pageResourcePath).Cast<CM_PageExpeditionSuccess>();
+        Logger.Verbose(LogLevel.Debug, $"CustomSuccessScreen should now be changed to {pageResourcePath}");
+    }
+
     private static void SetSuccessText(string text)
     {
         if (text == string.Empty)
             return;
 
+        var header = MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header;
+        var localizer = header.GetComponent<TMP_Localizer>();
         if (s_storedSuccessText == string.Empty)
         {
-            s_storedSuccessText = MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.text;
-            LevelAPI.OnBuildStart += RestoreSuccessText; // Any event that fires after the player leaves the success screen
+            s_storedSuccessText = localizer != null ? Text.Get(localizer.m_blockId) : header.text;
+            s_changedOrigText = s_storedPage == null;
+            if (s_changedOrigText)
+                LevelAPI.OnBuildStart += RestoreSuccessText; // Any event that fires after the player leaves the success screen
         }
 
-        MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(text);
+        header.SetText(text);
+        if (localizer != null)
+            GameObject.Destroy(localizer);
+
         Logger.Verbose(LogLevel.Debug, $"Set success screen text to {text}.");
     }
     
@@ -94,13 +118,27 @@ internal sealed class SetSuccessScreenEvent : BaseEvent
         Logger.Verbose(LogLevel.Debug, $"Set success screen music to sound id {music}.");
     }
 
+    private static void RestoreSuccessPage()
+    {
+        if (s_storedPage != null)
+        {
+            GameObject.Destroy(MainMenuGuiLayer.Current.PageExpeditionSuccess.gameObject);
+            MainMenuGuiLayer.Current.PageExpeditionSuccess = s_storedPage;
+            MainMenuGuiLayer.Current.m_pages[(int)eCM_MenuPage.CMP_EXPEDITION_SUCCESS] = s_storedPage;
+            s_storedPage = null;
+            LevelAPI.OnBuildStart -= RestoreSuccessPage;
+        }
+    }
+
     private static void RestoreSuccessText()
     {
         if (s_storedSuccessText != string.Empty)
         {
             MainMenuGuiLayer.Current.PageExpeditionSuccess.m_header.SetText(s_storedSuccessText);
             s_storedSuccessText = string.Empty;
-            LevelAPI.OnBuildStart -= RestoreSuccessText;
+            if (s_changedOrigText)
+                LevelAPI.OnBuildStart -= RestoreSuccessText;
+            s_changedOrigText = false;
         }
     }
     


### PR DESCRIPTION
Fixes:

- Custom success screens persisting through drops and never being destroyed, even if multiple are added.
- SpecialText not applying if a custom success screen was used.