### PR TITLE
Add FromLocation filter to TeleportPlayer

### DIFF
--- a/AWO/Modules/WEE/Events/Player/TeleportPlayerEvent.cs
+++ b/AWO/Modules/WEE/Events/Player/TeleportPlayerEvent.cs
@@ -1,6 +1,7 @@
 ﻿using AmorLib.Utils;
 using AmorLib.Utils.Extensions;
 using BepInEx.Logging;
+using GameData;
 using LevelGeneration;
 using Player;
 using System.Collections;
@@ -52,16 +53,19 @@ internal sealed class TeleportPlayerEvent : BaseEvent
         }
 
         var itemAssignment = AssignWarpables(tp, playersInLevel);
-
+        int usedCount = 0;
         for (int j = 0; j < playersInLevel.Count; j++)
         {
-            bool overflow = j >= 4 && tp.FullTeamOverflow && tp.TPData.Count == 4 && tp.TPData.Max(tpd => (int)tpd.PlayerIndex) < 4;
-            int p = overflow ? (j % 4) : j;
+            PlayerAgent player = playersInLevel[j];
+            if (!PlayerIsInLocation(player, tp.FromLocation)) continue;
+
+            bool overflow = usedCount >= 4 && tp.FullTeamOverflow && tp.TPData.Count == 4 && tp.TPData.Max(tpd => (int)tpd.PlayerIndex) < 4;
+            int p = overflow ? (usedCount % 4) : usedCount;
+            usedCount++;
             int idx = tp.TPData.FindIndex(tpd => (int)tpd.PlayerIndex == p);
             if (idx == -1) continue;
             var playerData = tp.TPData[idx];
 
-            PlayerAgent player = playersInLevel[j];
             var tpData = new TeleportData()
             {
                 Player = player,
@@ -191,5 +195,31 @@ internal sealed class TeleportPlayerEvent : BaseEvent
             return player.FPSCamera.CameraRayDir.normalized;
 
         return player.Sync.m_locomotionData.LookDir.Value;
+    }
+
+    private static bool PlayerIsInLocation(PlayerAgent player, WEE_TeleportPlayer.FromLocationData data)
+    {
+        if (!data.Enabled) return true;
+
+        var node = player.CourseNode;
+        if (node == null)
+        {
+            Logger.Verbose(LogLevel.Warning, $"Player {player.Owner.NickName} has no CourseNode, can't check FromLocation filter!");
+            return false;
+        }
+
+        (var playerDim, var playerLayer, var playerZone) = (player.DimensionIndex, node.LayerType, node.m_zone?.LocalIndex ?? eLocalZoneIndex.Zone_0);
+        foreach (var d in data.DimensionIndex.Values)
+        {
+            foreach (var l in data.Layer.Values)
+            {
+                foreach (var z in data.LocalIndex.Values)
+                {
+                    if (playerDim == d && playerLayer == l && playerZone == z)
+                        return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/AWO/Modules/WEE/WEE_EventData.cs
+++ b/AWO/Modules/WEE/WEE_EventData.cs
@@ -375,6 +375,7 @@ public sealed partial class WEE_TeleportPlayer // new
     public bool WarpBigPickups { get; set; } = true;
     public bool SendBigPickupsToHost { private get => SendBPUsToHost; set => SendBPUsToHost = value; }
     public bool FullTeamOverflow { get; set; } = false;
+    public FromLocationData FromLocation { get; set; } = new();
     public List<TeleportData> TPData { get; set; } = new();
     public struct TeleportData
     { 
@@ -401,6 +402,16 @@ public sealed partial class WEE_TeleportPlayer // new
         public Vector3 LastLookDirV3 { get; set; }
         [JsonIgnore]
         public List<IWarpableObject> ItemsToWarp { get; set; }
+    }
+
+    public struct FromLocationData
+    {
+        public bool Enabled { get; set; } = false;
+        public Arrayable<eDimensionIndex> DimensionIndex { get; set; } = new(eDimensionIndex.Reality);
+        public Arrayable<LG_LayerType> Layer { get; set; } = new(LG_LayerType.MainLayer);
+        public Arrayable<eLocalZoneIndex> LocalIndex { get; set; } = new(eLocalZoneIndex.Zone_0);
+
+        public FromLocationData() { }
     }
 }
 


### PR DESCRIPTION
Adds a filter to TeleportPlayer to only teleport players found in the target zone(s). For example, you could use this to close a security door and TP players that were behind it, preventing a softlock.

Wiki-formatted fields:

**FromLocation**\
If enabled, only teleports players found in the specified zone(s). TPData's PlayerIndex is changed to be the Xth player in the specified zone(s), in lobby join order.
- Type: FromLocationData

**Enabled**\
Whether to enable or disable the FromLocation filter.
- Type: bool
- Default: false

**DimensionIndex/Layer/LocalIndex**\
Which global index(s) FromLocation will search. Can be lists to search multiple zones.
- Type: Arrayable\<eDimensionIndex/LG_LayerType/eLocalZoneIndex> (enums)
- Default: Reality/MainLayer/Zone_0 (0/0/0)