### PR TITLE
Delete old puzzles for relevant events

### DIFF
--- a/AWO/Modules/WEE/Events/Door/AddChainPuzzleToSecurityDoor.cs
+++ b/AWO/Modules/WEE/Events/Door/AddChainPuzzleToSecurityDoor.cs
@@ -1,7 +1,10 @@
 ﻿using AmorLib.Utils;
+using BepInEx.Logging;
 using ChainedPuzzles;
 using GameData;
 using LevelGeneration;
+using System.Collections;
+using UnityEngine;
 
 namespace AWO.Modules.WEE.Events;
 
@@ -44,9 +47,11 @@ internal sealed class AddChainPuzzleToSecurityDoor : BaseEvent
                 case eDoorStatus.Closed_LockedWithPowerGenerator:
                 case eDoorStatus.Closed_LockedWithNoKey:
                 case eDoorStatus.Unlocked:
-                    if (door.m_locks.ChainedPuzzleToSolve != null && !door.m_locks.ChainedPuzzleToSolve.IsSolved)
+                    if (door.m_locks.ChainedPuzzleToSolve != null)
                     {
-                        LogWarning($"Door has an unsolved chained puzzle {door.m_locks.ChainedPuzzleToSolve.Data.persistentID}, overriding...");
+                        if (!door.m_locks.ChainedPuzzleToSolve.IsSolved)
+                            Logger.Verbose(LogLevel.Debug, $"Door has an unsolved chained puzzle {door.m_locks.ChainedPuzzleToSolve.Data.persistentID}, overriding...");
+                        CoroutineManager.StartCoroutine(DestroyScanDelayed(door.m_locks.ChainedPuzzleToSolve).WrapToIl2Cpp());
                     }
                     var puzzleInstance = ChainedPuzzleManager.CreatePuzzleInstance(block, door.Gate.ProgressionSourceArea, door.Gate.m_linksTo, pos, door.transform);
                     state.status = door.m_locks.SetupForChainedPuzzle(puzzleInstance);
@@ -70,8 +75,8 @@ internal sealed class AddChainPuzzleToSecurityDoor : BaseEvent
                         eSecurityDoorType.Apex => "ApexDoorClosed_Idle",
                         eSecurityDoorType.Bulkhead => "ClosedIdle",
                         _ => string.Empty
-                    });                    
-                    LogDebug($"Door has recieved new chained puzzle {chainPuzzle}");
+                    });
+                    Logger.Verbose(LogLevel.Debug, $"Door has recieved new chained puzzle {chainPuzzle}");
                     break;
 
                 default:
@@ -79,5 +84,14 @@ internal sealed class AddChainPuzzleToSecurityDoor : BaseEvent
                     break;
             }
         }        
+    }
+
+    private static IEnumerator DestroyScanDelayed(ChainedPuzzleInstance scan)
+    {
+        yield return new WaitForSeconds(1f);
+        foreach (var puzzle in scan.m_chainedPuzzleCores)
+            if (puzzle != null)
+                GameObject.Destroy(puzzle.Cast<MonoBehaviour>().gameObject);
+        GameObject.Destroy(scan.gameObject);
     }
 }

--- a/AWO/Modules/WEE/Events/Terminal/HideTerminalCommand.cs
+++ b/AWO/Modules/WEE/Events/Terminal/HideTerminalCommand.cs
@@ -1,4 +1,7 @@
-﻿using LevelGeneration;
+﻿using ChainedPuzzles;
+using LevelGeneration;
+using System.Collections;
+using UnityEngine;
 
 namespace AWO.Modules.WEE.Events;
 
@@ -37,8 +40,17 @@ internal sealed class HideTerminalCommand : BaseEvent
                 term.m_command.m_commandsPerEnum.Remove(command);
                 term.m_command.m_commandsPerString.Remove(cmdStr);
                 term.m_command.m_commandHelpStrings.Remove(command);
+                var events = term.m_command.m_commandEventMap[command];
                 term.m_command.m_commandEventMap.Remove(command);
                 term.m_command.m_commandPostOutputMap.Remove(command);
+                for (int i = 0; i < events.Count; i++)
+                {
+                    if (!term.TryGetChainPuzzleForCommand(command, i, out var puzzle) || puzzle == null) continue;
+                    // If a puzzle is in use, command is not done; just let it leak, too much effort to clean up later
+                    if (puzzle.IsActive)
+                        break;
+                    CoroutineManager.StartCoroutine(DestroyScanDelayed(puzzle).WrapToIl2Cpp());
+                }
             }
             else if (IsMaster)
             {
@@ -47,5 +59,14 @@ internal sealed class HideTerminalCommand : BaseEvent
                 term.m_stateReplicator.State = state;
             }
         }
+    }
+
+    private static IEnumerator DestroyScanDelayed(ChainedPuzzleInstance scan)
+    {
+        yield return new WaitForSeconds(1f);
+        foreach (var puzzle in scan.m_chainedPuzzleCores)
+            if (puzzle != null)
+                GameObject.Destroy(puzzle.Cast<MonoBehaviour>().gameObject);
+        GameObject.Destroy(scan.gameObject);
     }
 }


### PR DESCRIPTION
Destroys chain puzzles when "AddChainPuzzleToSecurityDoor" replaces a scan or "HideTerminalCommand" deletes a command with chain puzzles.

Delayed by 1s to allow scan completion graphics to finish if the triggering door/terminal runs the command on itself. Just a minor optimization to clean up scans that can't be accessed anymore.

*HideTerminalCommand doesn't remove the command from the command-to-puzzle dictionary, and technically this leaves destroyed references, but I believe it is impossible to remove from that dictionary thanks to IL2CPP. Notably, adding another command on the same index should attempt to use the same puzzles even though the command is different, which is a problem when the puzzles are destroyed. That said, this is buggy behavior even without the null ref so it's fine IMO.